### PR TITLE
Use a custom Error in case there's a uniqueness validation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,18 @@
 var _ = require('lodash');
 var async = require('async');
 var hash = require('object-hash');
+var util = require('util');
 
 var uniqueSchema;
 var UniqueModel;
+
+function DocumentNotUniqueError(message) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+};
+
+util.inherits(DocumentNotUniqueError, Error);
 
 function getValues(doc, paths) {
   var final = [];
@@ -69,7 +78,7 @@ function checkUnique(paths, doc, next) {
         if (!originalDoc) {
           return uniqueDoc.remove(cb);
         }
-        return cb(new Error('values ' + JSON.stringify(vals) + ' for paths ' + JSON.stringify(paths) + ' are not unique'));
+        return cb(new DocumentNotUniqueError('values ' + JSON.stringify(vals) + ' for paths ' + JSON.stringify(paths) + ' are not unique'));
       });
     });
   }
@@ -182,6 +191,8 @@ module.exports = function(schema, attrs) {
     removeExistingUnique(doc.schema._uniqueShard.paths, doc, forgetCb);
   });
 };
+
+module.exports.DocumentNotUniqueError = DocumentNotUniqueError;
 
 function getPaths(parentPath, schema) {
   return _.reduce(schema.tree, function(memo, node, path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-unique-shard",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "When sharding unique indexes are only allowed for keys matching the shard index. This module allows to still define other properties to be unique which will then be modelled using an additional collection to keep track of unique fields.",
   "main": "index.js",
   "scripts": {

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -60,6 +60,7 @@ describe('mongoose-unique-shard', function() {
         expect(err).to.not.be.ok;
         testModelConflicting.save(function(err) {
           expect(err).to.be.ok;
+          expect(err).to.be.an.instanceof(mongooseUniqueShard.DocumentNotUniqueError);
           expect(err.message).to.equal('values ["test"] for paths ["uniqueKey"] are not unique');
           done();
         });
@@ -75,6 +76,7 @@ describe('mongoose-unique-shard', function() {
         expect(err).to.not.be.ok;
         testModelConflicting.save(function(err) {
           expect(err).to.be.ok;
+          expect(err).to.be.an.instanceof(mongooseUniqueShard.DocumentNotUniqueError);
           expect(err.message).to.equal('values ["test"] for paths ["subdoc.uniqueSubKey"] are not unique');
           done();
         });
@@ -92,6 +94,7 @@ describe('mongoose-unique-shard', function() {
         expect(err).to.not.be.ok;
         testModelConflicting.save(function(err) {
           expect(err).to.be.ok;
+          expect(err).to.be.an.instanceof(mongooseUniqueShard.DocumentNotUniqueError);
           expect(err.message).to.equal('values ["val1","val2"] for paths ["combinedKey1","combinedKey2"] are not unique');
           done();
         });


### PR DESCRIPTION
This makes it easier to match the error.
